### PR TITLE
fix dead links

### DIFF
--- a/games/index.html
+++ b/games/index.html
@@ -60,25 +60,25 @@
         </li>
         <hr>
         <p><img src="net_globe.svg" width="24" style="margin-bottom: -6px; margin-left: -4px;"></img>&nbsp;&nbsp;<a title="WebAssembly Home Page" rel="noopener" target="_blank" href="https://webassembly.org/">WebAssembly</a> game ports by <a title="Midzer's Awesome Emscripten Repo" rel="noopener" target="_blank" href="https://github.com/midzer/awesome-emscripten">midzer</a>:</p>
-        <li><a title="Bombermaaan" rel="noopener" href="https://bombermaaan.netlify.app/">Bombermaaan</a>&nbsp;- Inspired by the classic Bomberman game.
+        <li><a title="Bombermaaan" rel="noopener" href="https://midzer.de/wasm/bombermaaan/">Bombermaaan</a>&nbsp;- Inspired by the classic Bomberman game.
         </li>
-        <li><a title="Chromium B.S.U." rel="noopener" href="https://chromium-bsu.netlify.app/">Chromium B.S.U.</a>&nbsp;- Arcade-style, top-scrolling space shooter.
+        <li><a title="Chromium B.S.U." rel="noopener" href="https://midzer.de/wasm/chromium-bsu/">Chromium B.S.U.</a>&nbsp;- Arcade-style, top-scrolling space shooter.
         </li>
-        <li><a title="C-Dogs SDL" rel="noopener" href="https://cdogs.netlify.app/">C-Dogs SDL</a>&nbsp;- Classic overhead run-and-gun game.
+        <li><a title="C-Dogs SDL" rel="noopener" href="https://midzer.de/wasm/cdogs/">C-Dogs SDL</a>&nbsp;- Classic overhead run-and-gun game.
         </li>
-        <li><a title="Der Clou!" rel="noopener" href="https://derclou.netlify.app/">Der Clou!</a>&nbsp;- Der Clou! SDL Port
+        <li><a title="Der Clou!" rel="noopener" href="https://midzer.de/wasm/derclou/">Der Clou!</a>&nbsp;- Der Clou! SDL Port
         </li>
-        <li><a title="OpenDUNE" rel="noopener" href="https://opendune.netlify.app/">OpenDUNE</a>&nbsp;- Dune II, Reinvented.
+        <li><a title="OpenDUNE" rel="noopener" href="https://midzer.de/wasm/opendune/">OpenDUNE</a>&nbsp;- Dune II, Reinvented.
         </li>
-        <li><a title="Freegemas" rel="noopener" href="https://freegemas.netlify.app/">Freegemas</a>&nbsp;- Bejeweled FOSS fork
+        <li><a title="Freegemas" rel="noopener" href="https://midzer.de/wasm/freegemas/">Freegemas</a>&nbsp;- Bejeweled FOSS fork
         </li>
-        <li><a title="Jump 'n Bump" rel="noopener" href="https://jumpnbump.netlify.app/">Jump 'n Bump</a>&nbsp;- Cute bunnies jumping on each other's heads
+        <li><a title="Jump 'n Bump" rel="noopener" href="https://midzer.de/wasm/jumpnbump/">Jump 'n Bump</a>&nbsp;- Cute bunnies jumping on each other's heads
         </li>
-        <li><a title="Raptor" rel="noopener" href="https://raptor-web.netlify.app/">Raptor</a>&nbsp;- Raptor: Call Of The Shadows, reverse Engineered
+        <li><a title="Raptor" rel="noopener" href="https://midzer.de/wasm/raptor/">Raptor</a>&nbsp;- Raptor: Call Of The Shadows, reverse Engineered
         </li>
-        <li><a title="REminiscence" rel="noopener" href="https://reminiscence-cd.netlify.app/">REminiscence</a>&nbsp;- Flashback from Delphine Software ported for the web
+        <li><a title="REminiscence" rel="noopener" href="https://github.com/midzer/reminiscence">REminiscence</a>&nbsp;- Flashback from Delphine Software ported for the web
         </li>
-        <li><a title="Wolfenstein 3D/Spear of Destiny" rel="noopener" href="https://wolfenstein.netlify.app/">Wolfenstein</a>&nbsp;- Wolfenstein 3D and Spear of Destiny
+        <li><a title="Wolfenstein 3D/Spear of Destiny" rel="noopener" href="https://midzer.de/wasm/wolfenstein/">Wolfenstein</a>&nbsp;- Wolfenstein 3D and Spear of Destiny
         </li>
         <p> - These use <a title="SDL Homepage" rel="noopener" target="_blank" href="https://www.libsdl.org/">SDL/SDL2</a> and <a title="Emscripten Homepage" rel="noopener" target="_blank" href="https://emscripten.org/">Emscripten</a> to compile local code for the Web.</p>
         <br>


### PR DESCRIPTION
these links weren't working - I went to the source and found the updated links

note the link to REminiscence, which just links to the source code on Github - not sure how useful that link is, and it does look like the author [tried](https://midzer.de/wasm/reminiscence/) to deploy it at `https://midzer.de/wasm/reminiscence/`, but it doesn't run. He hasn't provided a working link in the Github repo or on his website, so...
